### PR TITLE
削除：誤ったブランチ作成のため削除

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -169,6 +169,8 @@
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      
+      <% if @items.blank? then %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -181,6 +183,7 @@
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
+              <% end %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
# What
商品一覧表示機能の実装

# Why
レビューしていただいた点の修正

gyazo
https://gyazo.com/7ad001bd5ddd23b77b6a7075c30c1f17
※出品画像が存在するためダミー画像が表示されない→動画は一点になりますが、よろしいでしょうか？

※間違えて新規ブランチにしてしまいました。次回から気をつけます。